### PR TITLE
Address bug in issue #117

### DIFF
--- a/GRG/nls/strings.js
+++ b/GRG/nls/strings.js
@@ -160,6 +160,8 @@ define({
     "drawPointToolTip": 'Click to add GRG origin point', // Shown as tooltip help on the cursor when using the draw point tool
     "missingLayerNameMessage": 'You must enter a valid layer name before you can publish', //shown as error message for invalid layer name     
     "parseCoordinatesError": 'Unable to parse coordinates. Please check your input.', //Shown as error message for unknown coordinates
-    "grgPolarRegionError" :"The GRG extent is within a polar region. Cells that fall within the polar region will not be created." //Shown as warning message for GRG overlapping polar region
+    "grgPolarRegionError" :"The GRG extent is within a polar region. Cells that fall within the polar region will not be created.", //Shown as warning message for GRG overlapping polar region
+    "grgPolarOriginError" :"The GRG origin point cannot be within a polar region when creating a GRG by Reference System." //Shown as warning message for GRG origin in polar region
+  
   })
 });


### PR DESCRIPTION
The original fix for #117 had a slight bug that was affecting the create
Point GRG by Reference System. If the user tried to create a point GRG
within a polar region with a Grid Size that was not Grid Zone the GRG
would not be created and no warning was given.

On investigation if the grid origin point was in a polar region the
mgrs.USNGtoPoint() function returns a point that has NaN values for its
x and y. Added a check to exit the function with a warning message if
this occurs.

Also used this PR to address a slight issue with the order of the extent
graphics layer prevent the user from adjusting it because it was
displayed under the GRGarea layer.